### PR TITLE
Use correct namespace in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule ShortMaps.Mixfile do
+defmodule ShorterMaps.Mixfile do
   use Mix.Project
 
   @version "2.2.4"


### PR DESCRIPTION
`mix.exs` defines `ShortMaps.Mixfile` instead of `ShorterMaps.Mixfile`.  I assume this is left over from the initial fork.

In a project that includes both this library and the original short_maps library, this causes a redefinition warning:

```
warning: redefining module ShortMaps.Mixfile (current version defined in memory)
  /path/to/app/deps/shorter_maps/mix.exs:1
```